### PR TITLE
Transfer from Edgware to  Agile Content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
 include(ExternalProject)
 ExternalProject_Add(project_mpegts
-        GIT_REPOSITORY https://github.com/Unit-X/mpegts.git
+        GIT_REPOSITORY https://github.com/unit-x/mpegts.git
         GIT_SUBMODULES ""
         UPDATE_COMMAND git pull
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mpegts
@@ -23,7 +23,7 @@ add_library(mpegts STATIC IMPORTED)
 set_property(TARGET mpegts PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/mpegts/libmpegts.a)
 
 ExternalProject_Add(project_efp
-        GIT_REPOSITORY https://github.com/Unit-X/efp.git
+        GIT_REPOSITORY https://github.com/agilecontent/efp.git
         GIT_SUBMODULES ""
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Edgeware AB
+Copyright (c) 2020 Edgeware AB, 2021-2022 Agile Content
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This example uses EFP ([ElasticFramingProtocol](https://github.com/Unit-X/efp))
 
 [Kissnet](https://github.com/Ybalrid/kissnet) for sending/recieving UDP packets
 
-and [Akanchis TS-Demuxer](https://github.com/andersc/mpegts) for muxing/demuxing MPEG-TS
+and a patched [Akanchis TS-Demuxer](https://github.com/unit-x/mpegts) for muxing/demuxing MPEG-TS.
 
 ## Description
 
@@ -46,7 +46,4 @@ cmake --build . --config Debug
 
 *MIT*
 
-Read *LICENCE.md* for details
-
-
- 
+Read *LICENSE.md* for details


### PR DESCRIPTION
Transfer from unit-x to agilecontent Github repo.
This is part of major migration of EFP source code.